### PR TITLE
CI and workflow maintenance

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,8 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
-          - '1.1'
+          - 'min'
           - '1'
 #          - 'nightly'
         os:
@@ -23,7 +22,7 @@ jobs:
           - x64
     steps:
       - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -28,8 +28,6 @@ jobs:
     steps:
       - uses: JuliaRegistries/TagBot@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.TAGBOT_TOKEN }}
           # Edit the following line to reflect the actual name of the GitHub Secret containing your private key
-          ssh: ${{ secrets.DOCUMENTER_KEY }}
-          # ssh: ${{ secrets.NAME_OF_MY_SSH_PRIVATE_KEY_SECRET }}
           registry: HolyLab/HolyLabRegistry

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "RegisterWorkerShell"
 uuid = "978d31ce-2656-11e9-22d6-b5c46a1a3d3e"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Tim Holy <tim.holy@gmail.com>"]
 
 [deps]
@@ -21,7 +21,7 @@ ImageMetadata = "0.9"
 SharedArrays = "1"
 SimpleTraits = "0.8, 0.9"
 Test = "1"
-julia = "1"
+julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"


### PR DESCRIPTION
## Summary

- Raise julia compat lower bound to 1.10 (current LTS), bump patch version to 1.0.1
- Replace hardcoded CI matrix versions with `min`/`1`, update `setup-julia` to v2
- Switch TagBot to use `TAGBOT_TOKEN` secret and drop the unused Documenter SSH key

## Test plan

- [ ] CI passes on the `min` and `1` Julia versions
- [ ] TagBot triggers correctly on next release tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)